### PR TITLE
url and update parameters added

### DIFF
--- a/pi.easy_ical.php
+++ b/pi.easy_ical.php
@@ -31,7 +31,7 @@
 
 $plugin_info = array(
 	'pi_name'			=> 'Easy iCalendar',
-	'pi_version'		=> '1.0',
+	'pi_version'		=> '1.1',
 	'pi_author'			=> 'Crescendo Multimedia',
 	'pi_author_url'		=> 'http://www.crescendo.net.nz/',
 	'pi_description'	=> 'Create valid iCalendars in seconds',
@@ -59,7 +59,7 @@ class Easy_ical
 			$out .= "X-WR-CALNAME:".$this->escape($this->EE->TMPL->fetch_param('calname'))."\r\n";
 		}
 		
-		$out .= "PRODID:-//EE Easy iCalendar plugin//NONSGML v1.0//EN\r\n";
+		$out .= "PRODID:-//EE Easy iCalendar plugin//NONSGML v1.1//EN\r\n";
 		
 		// EE has probably put heaps of useless whitespace between each entry
 		$tagdata = trim($this->EE->TMPL->tagdata);
@@ -70,7 +70,14 @@ class Easy_ical
 		
 		// print output directly with the correct content-type
 		$content_type = $this->EE->TMPL->fetch_param('content_type');
-		if (empty($content_type)) $content_type = 'text/calendar; charset=UTF-8';
+		if (empty($content_type)){
+			$content_type = 'text/calendar; charset=UTF-8';
+		}
+		else if($content_type=='debug')
+		{
+			$content_type = 'text/html; charset=UTF-8';
+			$out ="<pre>".$out;
+		}
 		
 		header('Content-Type: '.$content_type);
 		exit($out);
@@ -97,6 +104,18 @@ class Easy_ical
 		if ($this->EE->TMPL->fetch_param('summary') !== FALSE)
 		{
 			$out .= "SUMMARY:".$this->escape($this->EE->TMPL->fetch_param('summary'))."\r\n";
+		}
+		
+		if ($this->EE->TMPL->fetch_param('update') !== FALSE)
+		{
+			if($this->EE->TMPL->fetch_param('update') !=='')
+			{
+				$out .= "SEQUENCE:".$this->escape($this->EE->TMPL->fetch_param('update'))."\r\n";
+			}
+		}
+		if ($this->EE->TMPL->fetch_param('url') !== FALSE)
+		{
+			$out .= "URL:".$this->escape($this->EE->TMPL->fetch_param('url'))."\r\n";
 		}
 		
 		$description = trim($this->EE->TMPL->tagdata);
@@ -155,6 +174,26 @@ Really basic, just construct a template with a channel entries tag, like so:
 All of the CRLF and escaping characters nonsense will be handled for you automatically.
 
 NOTE: Anything else in the template outside the {exp:easy_ical:calendar} tag will be ignored!
+
+Optional tag parameters
+--------------------------
+content_type="debug"
+ This will output the template with a html/text header and pre-tag for debugging. Or specify your own content_type.
+ Example: {exp:easy_ical:calendar content_type="debug ... }
+
+
+Parameters for the event tag
+Example: {exp:easy_ical:event url="{url_title_path='group/template'}" update="{revision_num} ... }
+
+url="{url_title_path='group/template'}"
+ This allows you to add a link to a calendar event entry
+
+update={number}
+ This adds a SEQUENCE=(number) to the event. Needed if you update an entry, otherwise iCal won't update the event.
+ Use a simple counter custom field, like http://github.com/GDmac/Reevision.ee_addon
+  
+--------------------------
+ 
 EOF;
 	}
 }

--- a/readme.markdown
+++ b/readme.markdown
@@ -1,0 +1,34 @@
+# Easy iCalendar
+
+Create valid iCalendars in seconds
+Usage: Really basic, just construct a template with a channel entries tag, like so:
+
+{exp:easy_ical:calendar timezone="Pacific/Auckland" name="My Easy Event Calendar"}
+ {exp:channel:entries channel="events" show_future_entries="yes" show_expired="yes" limit="20"}
+  {exp:easy_ical:event uid="{entry_id}" start_time="{entry_date}" end_time="{expiration_date}" location="{event_location}" summary="{title}"}
+   {event_description}
+  {/exp:easy_ical:event}
+ {/exp:channel:entries}
+{/exp:easy_ical:calendar}
+
+All of the CRLF and escaping characters nonsense will be handled for you automatically.
+NOTE: Anything else in the template outside the {exp:easy_ical:calendar} tag will be ignored!
+
+## Optional tag parameters
+--------------------------
+**content_type="debug"**
+This will output the template with a html/text header and pre-tag for debugging. Or specify your own content_type.  
+Example: {exp:easy_ical:calendar content_type="debug ... }
+
+
+### Parameters for the event tag
+Example: {exp:easy_ical:event url="{url_title_path='group/template'}" update="{revision_num} ... }
+
+**url="{url_title_path='group/template'}"**  
+This allows you to add a link to a calendar event entry
+
+**update={number}**
+This adds a SEQUENCE=(number) to the event. Needed if you update an entry, otherwise iCal won't update the event.  
+Use a simple counter custom field, like http://github.com/GDmac/Reevision.ee_addon
+
+--------------------------

--- a/readme.markdown
+++ b/readme.markdown
@@ -1,34 +1,33 @@
 # Easy iCalendar
 
-Create valid iCalendars in seconds
+Create valid iCalendars in seconds  
 Usage: Really basic, just construct a template with a channel entries tag, like so:
 
-{exp:easy_ical:calendar timezone="Pacific/Auckland" name="My Easy Event Calendar"}
- {exp:channel:entries channel="events" show_future_entries="yes" show_expired="yes" limit="20"}
-  {exp:easy_ical:event uid="{entry_id}" start_time="{entry_date}" end_time="{expiration_date}" location="{event_location}" summary="{title}"}
-   {event_description}
-  {/exp:easy_ical:event}
- {/exp:channel:entries}
-{/exp:easy_ical:calendar}
+	{exp:easy_ical:calendar timezone="Pacific/Auckland" name="My Easy Event Calendar"}
+		{exp:channel:entries channel="events" show_future_entries="yes" show_expired="yes" limit="20"}
+			{exp:easy_ical:event uid="{entry_id}" start_time="{entry_date}" end_time="{expiration_date}" location="{event_location}" summary="{title}"}
+				{event_description}
+			{/exp:easy_ical:event}
+		{/exp:channel:entries}
+	{/exp:easy_ical:calendar}
 
 All of the CRLF and escaping characters nonsense will be handled for you automatically.
-NOTE: Anything else in the template outside the {exp:easy_ical:calendar} tag will be ignored!
+
+*NOTE: Anything else in the template outside the {exp:easy_ical:calendar} tag will be ignored!*
 
 ## Optional tag parameters
---------------------------
-**content_type="debug"**
+
+### Parameters for the Calendar-tag
+**content_type="debug"**  
 This will output the template with a html/text header and pre-tag for debugging. Or specify your own content_type.  
 Example: {exp:easy_ical:calendar content_type="debug ... }
 
-
-### Parameters for the event tag
+### Parameters for the Event-tag
 Example: {exp:easy_ical:event url="{url_title_path='group/template'}" update="{revision_num} ... }
 
 **url="{url_title_path='group/template'}"**  
 This allows you to add a link to a calendar event entry
 
-**update={number}**
+**update={number}**  
 This adds a SEQUENCE=(number) to the event. Needed if you update an entry, otherwise iCal won't update the event.  
 Use a simple counter custom field, like http://github.com/GDmac/Reevision.ee_addon
-
---------------------------


### PR DESCRIPTION
url="{url_title_path='group/template'}"
Allows you to add a link to a calendar event entry

update={number}
This adds a SEQUENCE=(number) to the event.
Needed if you update an entry, otherwise iCal won't update the event.
Use a simple counter custom field, like http://github.com/GDmac/Reevision.ee_addon

Example from the spec:
The following is an example of this property for a calendar
component that was just created by the "Organizer".

```
SEQUENCE:0
```

The following is an example of this property for a calendar component
that has been revised two different times by the "Organizer".

```
SEQUENCE:2
```
